### PR TITLE
Remove pinned Java version in CI

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,13 +14,5 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-
-      - name: Setup JDK
-        uses: actions/setup-java@v3
-        with:
-          distribution: adopt
-          java-version: 11
-          cache: gradle
-
       - name: Run checks
         run: ./gradlew check --no-daemon --stacktrace


### PR DESCRIPTION
Perhaps better to use the default/latest tooling as much as possible until we incur into problems  