### PR TITLE
Global ctx passed into the provider via FeatureProvider

### DIFF
--- a/OpenFeature/src/main/java/dev/openfeature/sdk/FeatureProvider.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/FeatureProvider.kt
@@ -8,9 +8,9 @@ interface FeatureProvider {
     suspend fun initialize(initialContext: EvaluationContext?)
     // Called by OpenFeatureAPI whenever a new EvaluationContext is set by the application
     suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext)
-    fun getBooleanEvaluation(key: String, defaultValue: Boolean): ProviderEvaluation<Boolean>
-    fun getStringEvaluation(key: String, defaultValue: String): ProviderEvaluation<String>
-    fun getIntegerEvaluation(key: String, defaultValue: Int): ProviderEvaluation<Int>
-    fun getDoubleEvaluation(key: String, defaultValue: Double): ProviderEvaluation<Double>
-    fun getObjectEvaluation(key: String, defaultValue: Value): ProviderEvaluation<Value>
+    fun getBooleanEvaluation(key: String, defaultValue: Boolean, context: EvaluationContext?): ProviderEvaluation<Boolean>
+    fun getStringEvaluation(key: String, defaultValue: String, context: EvaluationContext?): ProviderEvaluation<String>
+    fun getIntegerEvaluation(key: String, defaultValue: Int, context: EvaluationContext?): ProviderEvaluation<Int>
+    fun getDoubleEvaluation(key: String, defaultValue: Double, context: EvaluationContext?): ProviderEvaluation<Double>
+    fun getObjectEvaluation(key: String, defaultValue: Value, context: EvaluationContext?): ProviderEvaluation<Value>
 }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/HookContext.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/HookContext.kt
@@ -4,7 +4,7 @@ data class HookContext<T>(
     var flagKey: String,
     val type: FlagValueType,
     var defaultValue: T,
-    var ctx: EvaluationContext,
+    var ctx: EvaluationContext?,
     var clientMetadata: Metadata?,
     var providerMetadata: Metadata
 )

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/NoOpProvider.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/NoOpProvider.kt
@@ -16,35 +16,40 @@ class NoOpProvider : FeatureProvider {
     override var hooks: List<Hook<*>> = listOf()
     override fun getBooleanEvaluation(
         key: String,
-        defaultValue: Boolean
+        defaultValue: Boolean,
+        context: EvaluationContext?
     ): ProviderEvaluation<Boolean> {
         return ProviderEvaluation(defaultValue, "Passed in default", Reason.DEFAULT.toString())
     }
 
     override fun getStringEvaluation(
         key: String,
-        defaultValue: String
+        defaultValue: String,
+        context: EvaluationContext?
     ): ProviderEvaluation<String> {
         return ProviderEvaluation(defaultValue, "Passed in default", Reason.DEFAULT.toString())
     }
 
     override fun getIntegerEvaluation(
         key: String,
-        defaultValue: Int
+        defaultValue: Int,
+        context: EvaluationContext?
     ): ProviderEvaluation<Int> {
         return ProviderEvaluation(defaultValue, "Passed in default", Reason.DEFAULT.toString())
     }
 
     override fun getDoubleEvaluation(
         key: String,
-        defaultValue: Double
+        defaultValue: Double,
+        context: EvaluationContext?
     ): ProviderEvaluation<Double> {
         return ProviderEvaluation(defaultValue, "Passed in default", Reason.DEFAULT.toString())
     }
 
     override fun getObjectEvaluation(
         key: String,
-        defaultValue: Value
+        defaultValue: Value,
+        context: EvaluationContext?
     ): ProviderEvaluation<Value> {
         return ProviderEvaluation(defaultValue, "Passed in default", Reason.DEFAULT.toString())
     }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/OpenFeatureClient.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/OpenFeatureClient.kt
@@ -165,13 +165,14 @@ class OpenFeatureClient(
         var details = FlagEvaluationDetails(key, defaultValue)
         val provider = openFeatureAPI.getProvider() ?: NoOpProvider()
         val mergedHooks: List<Hook<*>> = provider.hooks + options.hooks + hooks + openFeatureAPI.hooks
-        val context = openFeatureAPI.getEvaluationContext() ?: MutableContext()
+        val context = openFeatureAPI.getEvaluationContext()
         val hookCtx: HookContext<T> = HookContext(key, flagValueType, defaultValue, context, this.metadata, provider.metadata)
         try {
             hookSupport.beforeHooks(flagValueType, hookCtx, mergedHooks, hints)
             val providerEval = createProviderEvaluation(
                 flagValueType,
                 key,
+                context,
                 defaultValue,
                 provider
             )
@@ -197,33 +198,34 @@ class OpenFeatureClient(
     private fun <V> createProviderEvaluation(
         flagValueType: FlagValueType,
         key: String,
+        context: EvaluationContext?,
         defaultValue: V,
         provider: FeatureProvider
     ): ProviderEvaluation<V> {
         return when(flagValueType) {
             BOOLEAN -> {
                 val defaultBoolean = defaultValue as? Boolean ?: throw typeMatchingException
-                val eval: ProviderEvaluation<Boolean> = provider.getBooleanEvaluation(key, defaultBoolean)
+                val eval: ProviderEvaluation<Boolean> = provider.getBooleanEvaluation(key, defaultBoolean, context)
                 eval as? ProviderEvaluation<V> ?: throw typeMatchingException
             }
             STRING -> {
                 val defaultString = defaultValue as? String ?: throw typeMatchingException
-                val eval: ProviderEvaluation<String> = provider.getStringEvaluation(key, defaultString)
+                val eval: ProviderEvaluation<String> = provider.getStringEvaluation(key, defaultString, context)
                 eval as? ProviderEvaluation<V> ?: throw typeMatchingException
             }
             INTEGER -> {
                 val defaultInteger = defaultValue as? Int ?: throw typeMatchingException
-                val eval: ProviderEvaluation<Int> = provider.getIntegerEvaluation(key, defaultInteger)
+                val eval: ProviderEvaluation<Int> = provider.getIntegerEvaluation(key, defaultInteger, context)
                 eval as? ProviderEvaluation<V> ?: throw typeMatchingException
             }
             DOUBLE -> {
                 val defaultDouble = defaultValue as? Double ?: throw typeMatchingException
-                val eval: ProviderEvaluation<Double> = provider.getDoubleEvaluation(key, defaultDouble)
+                val eval: ProviderEvaluation<Double> = provider.getDoubleEvaluation(key, defaultDouble, context)
                 eval as? ProviderEvaluation<V> ?: throw typeMatchingException
             }
             OBJECT -> {
                 val defaultObject = defaultValue as? Value ?: throw typeMatchingException
-                val eval: ProviderEvaluation<Value> = provider.getObjectEvaluation(key, defaultObject)
+                val eval: ProviderEvaluation<Value> = provider.getObjectEvaluation(key, defaultObject, context)
                 eval as? ProviderEvaluation<V> ?: throw typeMatchingException
             }
         }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/exceptions/OpenFeatureError.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/exceptions/OpenFeatureError.kt
@@ -17,7 +17,7 @@ sealed class OpenFeatureError : Exception() {
     }
 
     class InvalidContextError(
-        override val message: String = "Invalid context"): OpenFeatureError() {
+        override val message: String = "Invalid or missing context"): OpenFeatureError() {
         override fun errorCode(): ErrorCode {
             return ErrorCode.INVALID_CONTEXT
         }

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/DeveloperExperienceTests.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/DeveloperExperienceTests.kt
@@ -19,14 +19,14 @@ class DeveloperExperienceTests {
 
     @Test
     fun testSimpleBooleanFlag() = runTest {
-        OpenFeatureAPI.setProvider(NoOpProvider())
+        OpenFeatureAPI.setProvider(NoOpProvider(), MutableContext())
         val booleanValue = OpenFeatureAPI.getClient().getBooleanValue("test", false)
         Assert.assertFalse(booleanValue)
     }
 
     @Test
     fun testClientHooks() = runTest {
-        OpenFeatureAPI.setProvider(NoOpProvider())
+        OpenFeatureAPI.setProvider(NoOpProvider(), MutableContext())
         val client = OpenFeatureAPI.getClient()
 
         val hook = GenericSpyHookMock()
@@ -38,7 +38,7 @@ class DeveloperExperienceTests {
 
     @Test
     fun testEvalHooks() = runTest {
-        OpenFeatureAPI.setProvider(NoOpProvider())
+        OpenFeatureAPI.setProvider(NoOpProvider(), MutableContext())
         val client = OpenFeatureAPI.getClient()
 
         val hook = GenericSpyHookMock()
@@ -50,7 +50,7 @@ class DeveloperExperienceTests {
 
     @Test
     fun testBrokenProvider() = runTest {
-        OpenFeatureAPI.setProvider(AlwaysBrokenProvider())
+        OpenFeatureAPI.setProvider(AlwaysBrokenProvider(), MutableContext())
         val client = OpenFeatureAPI.getClient()
 
         val details = client.getBooleanDetails("test", false)

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/ProviderSpecTests.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/ProviderSpecTests.kt
@@ -9,26 +9,26 @@ class ProviderSpecTests {
     fun testFlagValueSet() {
         val provider = NoOpProvider()
 
-        val boolResult = provider.getBooleanEvaluation("key", false)
+        val boolResult = provider.getBooleanEvaluation("key", false, MutableContext())
         Assert.assertNotNull(boolResult.value)
 
-        val stringResult = provider.getStringEvaluation("key", "test")
+        val stringResult = provider.getStringEvaluation("key", "test", MutableContext())
         Assert.assertNotNull(stringResult.value)
 
-        val intResult = provider.getIntegerEvaluation("key", 4)
+        val intResult = provider.getIntegerEvaluation("key", 4, MutableContext())
         Assert.assertNotNull(intResult.value)
 
-        val doubleResult = provider.getDoubleEvaluation("key", 0.4)
+        val doubleResult = provider.getDoubleEvaluation("key", 0.4, MutableContext())
         Assert.assertNotNull(doubleResult.value)
 
-        val objectResult = provider.getObjectEvaluation("key", Value.Null)
+        val objectResult = provider.getObjectEvaluation("key", Value.Null, MutableContext())
         Assert.assertNotNull(objectResult.value)
     }
 
     @Test
     fun testHasReason() {
         val provider = NoOpProvider()
-        val boolResult = provider.getBooleanEvaluation("key", false)
+        val boolResult = provider.getBooleanEvaluation("key", false, MutableContext())
 
         Assert.assertEquals(Reason.DEFAULT.toString(), boolResult.reason)
     }
@@ -36,7 +36,7 @@ class ProviderSpecTests {
     @Test
     fun testNoErrorCodeByDefault() {
         val provider = NoOpProvider()
-        val boolResult = provider.getBooleanEvaluation("key", false)
+        val boolResult = provider.getBooleanEvaluation("key", false, MutableContext())
 
         Assert.assertNull(boolResult.errorCode)
     }
@@ -45,19 +45,19 @@ class ProviderSpecTests {
     fun testVariantIsSet() {
         val provider = NoOpProvider()
 
-        val boolResult = provider.getBooleanEvaluation("key", false)
+        val boolResult = provider.getBooleanEvaluation("key", false, MutableContext())
         Assert.assertNotNull(boolResult.variant)
 
-        val stringResult = provider.getStringEvaluation("key", "test")
+        val stringResult = provider.getStringEvaluation("key", "test", MutableContext())
         Assert.assertNotNull(stringResult.variant)
 
-        val intResult = provider.getIntegerEvaluation("key", 4)
+        val intResult = provider.getIntegerEvaluation("key", 4, MutableContext())
         Assert.assertNotNull(intResult.variant)
 
-        val doubleResult = provider.getDoubleEvaluation("key", 0.4)
+        val doubleResult = provider.getDoubleEvaluation("key", 0.4, MutableContext())
         Assert.assertNotNull(doubleResult.variant)
 
-        val objectResult = provider.getObjectEvaluation("key", Value.Null)
+        val objectResult = provider.getObjectEvaluation("key", Value.Null, MutableContext())
         Assert.assertNotNull(objectResult.variant)
     }
 }

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/AlwaysBrokenProvider.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/AlwaysBrokenProvider.kt
@@ -17,35 +17,40 @@ class AlwaysBrokenProvider(override var hooks: List<Hook<*>> = listOf(), overrid
 
     override fun getBooleanEvaluation(
         key: String,
-        defaultValue: Boolean
+        defaultValue: Boolean,
+        context: EvaluationContext?
     ): ProviderEvaluation<Boolean> {
         throw FlagNotFoundError(key)
     }
 
     override fun getStringEvaluation(
         key: String,
-        defaultValue: String
+        defaultValue: String,
+        context: EvaluationContext?
     ): ProviderEvaluation<String> {
         throw FlagNotFoundError(key)
     }
 
     override fun getIntegerEvaluation(
         key: String,
-        defaultValue: Int
+        defaultValue: Int,
+        context: EvaluationContext?
     ): ProviderEvaluation<Int> {
         throw FlagNotFoundError(key)
     }
 
     override fun getDoubleEvaluation(
         key: String,
-        defaultValue: Double
+        defaultValue: Double,
+        context: EvaluationContext?
     ): ProviderEvaluation<Double> {
         throw FlagNotFoundError(key)
     }
 
     override fun getObjectEvaluation(
         key: String,
-        defaultValue: Value
+        defaultValue: Value,
+        context: EvaluationContext?
     ): ProviderEvaluation<Value> {
         throw FlagNotFoundError(key)
     }

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/DoSomethingProvider.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/DoSomethingProvider.kt
@@ -16,35 +16,40 @@ class DoSomethingProvider(override val hooks: List<Hook<*>> = listOf(), override
 
     override fun getBooleanEvaluation(
         key: String,
-        defaultValue: Boolean
+        defaultValue: Boolean,
+        context: EvaluationContext?
     ): ProviderEvaluation<Boolean> {
         return ProviderEvaluation(!defaultValue)
     }
 
     override fun getStringEvaluation(
         key: String,
-        defaultValue: String
+        defaultValue: String,
+        context: EvaluationContext?
     ): ProviderEvaluation<String> {
         return ProviderEvaluation(defaultValue.reversed())
     }
 
     override fun getIntegerEvaluation(
         key: String,
-        defaultValue: Int
+        defaultValue: Int,
+        context: EvaluationContext?
     ): ProviderEvaluation<Int> {
         return ProviderEvaluation(defaultValue * 100)
     }
 
     override fun getDoubleEvaluation(
         key: String,
-        defaultValue: Double
+        defaultValue: Double,
+        context: EvaluationContext?
     ): ProviderEvaluation<Double> {
         return ProviderEvaluation(defaultValue * 100)
     }
 
     override fun getObjectEvaluation(
         key: String,
-        defaultValue: Value
+        defaultValue: Value,
+        context: EvaluationContext?
     ): ProviderEvaluation<Value> {
         return ProviderEvaluation(Value.Null)
     }


### PR DESCRIPTION
More context about this change here: https://github.com/open-feature/ofep/pull/41#discussion_r1138650302 (with the related specification now merged in `main` at the end of [this section](https://github.com/open-feature/ofep/blob/008c98f657ffaba506047def48a0e74a186b0e66/OFEP-single-context-paradigm.md#initialize-function)) 

Within a single evaluation, the SDK now propagates the _same Context data_ all the way to the Provider. This ensures that the same Context data is used in the Hooks and in the Provider's Evaluation, preventing possible race conditions caused by the single global Context being read multiple times within the same evaluation   

