### PR TITLE
Move away from java.time.Instant

### DIFF
--- a/OpenFeature/src/main/java/dev/openfeature/sdk/Value.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/Value.kt
@@ -1,5 +1,6 @@
 package dev.openfeature.sdk
 
+import android.annotation.SuppressLint
 import dev.openfeature.sdk.exceptions.OpenFeatureError
 import kotlinx.serialization.KSerializer
 import kotlinx.serialization.Serializable
@@ -10,7 +11,9 @@ import kotlinx.serialization.encoding.Encoder
 import kotlinx.serialization.json.JsonContentPolymorphicSerializer
 import kotlinx.serialization.json.JsonElement
 import kotlinx.serialization.json.jsonObject
-import java.time.Instant
+import java.text.SimpleDateFormat
+import java.util.Date
+import java.util.TimeZone
 
 @Serializable(with = ValueSerializer::class)
 sealed interface Value {
@@ -19,7 +22,7 @@ sealed interface Value {
     fun asBoolean(): kotlin.Boolean? = if (this is Boolean) boolean else null
     fun asInteger(): Int? = if (this is Integer) integer else null
     fun asDouble(): kotlin.Double? = if (this is Double) double else null
-    fun asInstant(): java.time.Instant? = if (this is Instant) instant else null
+    fun asInstant(): Date? = if (this is Instant) instant else null
     fun asList(): kotlin.collections.List<Value>? = if (this is List) list else null
     fun asStructure(): Map<kotlin.String, Value>? = if (this is Structure) structure else null
     fun isNull(): kotlin.Boolean = this is Null
@@ -37,7 +40,7 @@ sealed interface Value {
     data class Double(val double: kotlin.Double) : Value
 
     @Serializable
-    data class Instant(@Serializable(InstantSerializer::class) val instant: java.time.Instant) : Value
+    data class Instant(@Serializable(DateSerializer::class) val instant: Date) : Value
 
     @Serializable
     data class Structure(val structure: Map<kotlin.String, Value>) : Value
@@ -70,8 +73,14 @@ object ValueSerializer : JsonContentPolymorphicSerializer<Value>(Value::class) {
     }
 }
 
-object InstantSerializer : KSerializer<Instant> {
+object DateSerializer : KSerializer<Date> {
+    @SuppressLint("SimpleDateFormat")
+    private val df = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss'Z'").apply { timeZone = TimeZone.getTimeZone("UTC") }
     override val descriptor = PrimitiveSerialDescriptor("Instant", PrimitiveKind.STRING)
-    override fun serialize(encoder: Encoder, value: Instant) = encoder.encodeString(value.toString())
-    override fun deserialize(decoder: Decoder): Instant = Instant.parse(decoder.decodeString())
+    override fun serialize(encoder: Encoder, value: Date) = encoder.encodeString(df.format(value))
+    override fun deserialize(decoder: Decoder): Date = try {
+        df.parse(decoder.decodeString()) ?: throw IllegalArgumentException("unable to parse ${decoder.decodeString()}")
+    } catch (e: Exception) {
+        throw IllegalArgumentException(e)
+    }
 }

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/EvalContextTests.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/EvalContextTests.kt
@@ -2,7 +2,7 @@ package dev.openfeature.sdk
 
 import org.junit.Assert
 import org.junit.Test
-import java.time.Instant
+import java.util.Date
 
 class EvalContextTests {
 
@@ -16,7 +16,7 @@ class EvalContextTests {
     @Test
     fun testContextStoresPrimitiveValues() {
         val ctx = MutableContext()
-        val now = Instant.now()
+        val now = Date()
 
         ctx.add("string", Value.String("value"))
         Assert.assertEquals("value", ctx.getValue("string")?.asString())
@@ -67,7 +67,7 @@ class EvalContextTests {
     @Test
     fun testContextCanConvertToMap() {
         val ctx = MutableContext()
-        val now = Instant.now()
+        val now = Date()
         ctx.add("str1", Value.String("test1"))
         ctx.add("str2", Value.String("test2"))
         ctx.add("bool1", Value.Boolean(true))
@@ -126,7 +126,7 @@ class EvalContextTests {
     @Test
     fun testContextConvertsToObjectMap() {
         val key = "key1"
-        val now = Instant.now()
+        val now = Date()
         val ctx = MutableContext(key)
         ctx.add("string", Value.String("value"))
         ctx.add("bool", Value.Boolean(false))

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/StructureTests.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/StructureTests.kt
@@ -2,7 +2,7 @@ package dev.openfeature.sdk
 
 import org.junit.Assert
 import org.junit.Test
-import java.time.Instant
+import java.util.Date
 
 class StructureTests {
 
@@ -23,7 +23,7 @@ class StructureTests {
 
     @Test
     fun testAddAndGetReturnValues() {
-        val now = Instant.now()
+        val now = Date()
         val structure = MutableStructure()
         structure.add("bool", Value.Boolean(true))
         structure.add("string", Value.String("val"))

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/ValueTests.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/ValueTests.kt
@@ -6,6 +6,7 @@ import kotlinx.serialization.json.encodeToJsonElement
 import org.junit.Assert
 import org.junit.Test
 import java.time.Instant
+import java.util.Date
 
 class ValueTests {
 
@@ -59,7 +60,7 @@ class ValueTests {
 
     @Test
     fun testEncodeDecode() {
-        val date = Instant.parse("2023-03-01T14:01:46Z")
+        val date = Date.from(Instant.parse("2023-03-01T14:01:46Z"))
         val value = Value.Structure(
             mapOf(
                 "null" to Value.Null,
@@ -127,7 +128,7 @@ class ValueTests {
                 "bool" to Value.Boolean(true),
                 "int" to Value.Integer(3),
                 "double" to Value.Double(4.5),
-                "date" to Value.Instant(Instant.parse(stringInstant)),
+                "date" to Value.Instant(Date.from(Instant.parse(stringInstant))),
                 "list" to Value.List(listOf(Value.Boolean(false), Value.Integer(4))),
                 "structure" to Value.Structure(mapOf("int" to Value.Integer(5)))
             )


### PR DESCRIPTION
For the main source set we want to back the Instant with a Date object to allow for a lower minSDK without desugaring