### PR TITLE
Make Structure and Context implementations immutable

### DIFF
--- a/OpenFeature/src/main/java/dev/openfeature/sdk/ImmutableContext.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/ImmutableContext.kt
@@ -1,8 +1,8 @@
 package dev.openfeature.sdk
 
-class MutableContext
-(private var targetingKey: String = "", attributes: MutableMap<String, Value> = mutableMapOf()) : EvaluationContext {
-    private var structure: MutableStructure = MutableStructure(attributes)
+class ImmutableContext
+(private var targetingKey: String = "", attributes: Map<String, Value> = mapOf()) : EvaluationContext {
+    private var structure: ImmutableStructure = ImmutableStructure(attributes)
     override fun getTargetingKey(): String {
         return targetingKey
     }
@@ -19,17 +19,12 @@ class MutableContext
         return structure.getValue(key)
     }
 
-    override fun asMap(): MutableMap<String, Value> {
+    override fun asMap(): Map<String, Value> {
         return structure.asMap()
     }
 
     override fun asObjectMap(): Map<String, Any?> {
         return structure.asObjectMap()
-    }
-
-    fun add(key: String, value: Value): MutableContext {
-        structure.add(key, value)
-        return this
     }
 
     override fun hashCode(): Int {
@@ -42,7 +37,7 @@ class MutableContext
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as MutableContext
+        other as ImmutableContext
 
         if (targetingKey != other.targetingKey) return false
         if (structure != other.structure) return false

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/ImmutableStructure.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/ImmutableStructure.kt
@@ -1,6 +1,6 @@
 package dev.openfeature.sdk
 
-class MutableStructure(private var attributes: MutableMap<String, Value> = mutableMapOf()) : Structure {
+class ImmutableStructure(private var attributes: Map<String, Value> = mapOf()) : Structure {
     override fun keySet(): Set<String> {
         return attributes.keys
     }
@@ -9,17 +9,12 @@ class MutableStructure(private var attributes: MutableMap<String, Value> = mutab
         return attributes[key]
     }
 
-    override fun asMap(): MutableMap<String, Value> {
+    override fun asMap(): Map<String, Value> {
         return attributes
     }
 
     override fun asObjectMap(): Map<String, Any?> {
         return attributes.mapValues { convertValue(it.value) }
-    }
-
-    fun add(key: String, value: Value): MutableStructure {
-        attributes[key] = value
-        return this
     }
 
     private fun convertValue(value: Value): Any? {
@@ -43,7 +38,7 @@ class MutableStructure(private var attributes: MutableMap<String, Value> = mutab
         if (this === other) return true
         if (javaClass != other?.javaClass) return false
 
-        other as MutableStructure
+        other as ImmutableStructure
 
         if (attributes != other.attributes) return false
 

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/Structure.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/Structure.kt
@@ -3,7 +3,7 @@ package dev.openfeature.sdk
 interface Structure {
     fun keySet(): Set<String>
     fun getValue(key: String): Value?
-    fun asMap(): MutableMap<String, Value>
+    fun asMap(): Map<String, Value>
     fun asObjectMap(): Map<String, Any?>
 
     // Make sure these are implemented for correct object comparisons

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/DeveloperExperienceTests.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/DeveloperExperienceTests.kt
@@ -19,14 +19,14 @@ class DeveloperExperienceTests {
 
     @Test
     fun testSimpleBooleanFlag() = runTest {
-        OpenFeatureAPI.setProvider(NoOpProvider(), MutableContext())
+        OpenFeatureAPI.setProvider(NoOpProvider(), ImmutableContext())
         val booleanValue = OpenFeatureAPI.getClient().getBooleanValue("test", false)
         Assert.assertFalse(booleanValue)
     }
 
     @Test
     fun testClientHooks() = runTest {
-        OpenFeatureAPI.setProvider(NoOpProvider(), MutableContext())
+        OpenFeatureAPI.setProvider(NoOpProvider(), ImmutableContext())
         val client = OpenFeatureAPI.getClient()
 
         val hook = GenericSpyHookMock()
@@ -38,7 +38,7 @@ class DeveloperExperienceTests {
 
     @Test
     fun testEvalHooks() = runTest {
-        OpenFeatureAPI.setProvider(NoOpProvider(), MutableContext())
+        OpenFeatureAPI.setProvider(NoOpProvider(), ImmutableContext())
         val client = OpenFeatureAPI.getClient()
 
         val hook = GenericSpyHookMock()
@@ -50,7 +50,7 @@ class DeveloperExperienceTests {
 
     @Test
     fun testBrokenProvider() = runTest {
-        OpenFeatureAPI.setProvider(AlwaysBrokenProvider(), MutableContext())
+        OpenFeatureAPI.setProvider(AlwaysBrokenProvider(), ImmutableContext())
         val client = OpenFeatureAPI.getClient()
 
         val details = client.getBooleanDetails("test", false)

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/EvalContextTests.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/EvalContextTests.kt
@@ -8,39 +8,42 @@ class EvalContextTests {
 
     @Test
     fun testContextStoresTargetingKey() {
-        val ctx = MutableContext()
+        val ctx = ImmutableContext()
         ctx.setTargetingKey("test")
         Assert.assertEquals("test", ctx.getTargetingKey())
     }
 
     @Test
     fun testContextStoresPrimitiveValues() {
-        val ctx = MutableContext()
         val now = Date()
+        val ctx = ImmutableContext(
+            attributes = mapOf(
+                "string" to Value.String("value"),
+                "bool" to Value.Boolean(true),
+                "int" to Value.Integer(3),
+                "double" to Value.Double(3.14),
+                "date" to Value.Date(now)
+            )
+        )
 
-        ctx.add("string", Value.String("value"))
         Assert.assertEquals("value", ctx.getValue("string")?.asString())
-        ctx.add("bool", Value.Boolean(true))
         Assert.assertEquals(true, ctx.getValue("bool")?.asBoolean())
-        ctx.add("int", Value.Integer(3))
         Assert.assertEquals(3, ctx.getValue("int")?.asInteger())
-        ctx.add("double", Value.Double(3.14))
         Assert.assertEquals(3.14, ctx.getValue("double")?.asDouble())
-        ctx.add("date", Value.Date(now))
         Assert.assertEquals(now, ctx.getValue("date")?.asDate())
     }
 
     @Test
     fun testContextStoresLists() {
-        val ctx = MutableContext()
-
-        ctx.add(
-            "list",
-            Value.List(
-                listOf(
-                    Value.Integer(3),
-                    Value.String("4")
-                )
+        val ctx = ImmutableContext(
+            attributes = mapOf(
+                "list" to
+                    Value.List(
+                        listOf(
+                            Value.Integer(3),
+                            Value.String("4")
+                        )
+                    )
             )
         )
         Assert.assertEquals(3, ctx.getValue("list")?.asList()?.get(0)?.asInteger())
@@ -49,15 +52,15 @@ class EvalContextTests {
 
     @Test
     fun testContextStoresStructures() {
-        val ctx = MutableContext()
-
-        ctx.add(
-            "struct",
-            Value.Structure(
-                mapOf(
-                    "string" to Value.String("test"),
-                    "int" to Value.Integer(3)
-                )
+        val ctx = ImmutableContext(
+            attributes = mapOf(
+                "struct" to
+                    Value.Structure(
+                        mapOf(
+                            "string" to Value.String("test"),
+                            "int" to Value.Integer(3)
+                        )
+                    )
             )
         )
         Assert.assertEquals("test", ctx.getValue("struct")?.asStructure()?.get("string")?.asString())
@@ -66,16 +69,20 @@ class EvalContextTests {
 
     @Test
     fun testContextCanConvertToMap() {
-        val ctx = MutableContext()
         val now = Date()
-        ctx.add("str1", Value.String("test1"))
-        ctx.add("str2", Value.String("test2"))
-        ctx.add("bool1", Value.Boolean(true))
-        ctx.add("bool2", Value.Boolean(false))
-        ctx.add("int1", Value.Integer(4))
-        ctx.add("int2", Value.Integer(2))
-        ctx.add("dt", Value.Date(now))
-        ctx.add("obj", Value.Structure(mapOf("val1" to Value.Integer(1), "val2" to Value.String("2"))))
+        val ctx = ImmutableContext(
+            attributes = mapOf(
+                "str1" to Value.String("test1"),
+                "str2" to Value.String("test2"),
+                "bool1" to Value.Boolean(true),
+                "bool2" to Value.Boolean(false),
+                "int1" to Value.Integer(4),
+                "int2" to Value.Integer(2),
+                "double" to Value.Double(3.14),
+                "dt" to Value.Date(now),
+                "obj" to Value.Structure(mapOf("val1" to Value.Integer(1), "val2" to Value.String("2")))
+            )
+        )
 
         val map = ctx.asMap()
         val structure = map["obj"]?.asStructure()
@@ -92,33 +99,23 @@ class EvalContextTests {
 
     @Test
     fun testContextHasUniqueKeyAcrossTypes() {
-        val ctx = MutableContext()
-
-        ctx.add("key", Value.String("val1"))
-        ctx.add("key", Value.String("val2"))
-        Assert.assertEquals("val2", ctx.getValue("key")?.asString())
-
-        ctx.add("key", Value.Integer(3))
+        val ctx = ImmutableContext(
+            attributes = mapOf(
+                "key" to Value.String("val1"),
+                "key" to Value.Integer(3)
+            )
+        )
         Assert.assertNull(ctx.getValue("key")?.asString())
         Assert.assertEquals(3, ctx.getValue("key")?.asInteger())
     }
 
     @Test
-    fun testContextCanChainAttributeAddition() {
-        val ctx = MutableContext()
-
-        val result =
-            ctx.add("key1", Value.String("val1"))
-        ctx.add("key2", Value.String("val2"))
-        Assert.assertEquals("val1", result.getValue("key1")?.asString())
-        Assert.assertEquals("val2", result.getValue("key2")?.asString())
-    }
-
-    @Test
-    fun testContextCanAddNull() {
-        val ctx = MutableContext()
-
-        ctx.add("null", Value.Null)
+    fun testContextStoresNull() {
+        val ctx = ImmutableContext(
+            attributes = mapOf(
+                "null" to Value.Null
+            )
+        )
         Assert.assertEquals(true, ctx.getValue("null")?.isNull())
         Assert.assertNull(ctx.getValue("null")?.asString())
     }
@@ -127,20 +124,21 @@ class EvalContextTests {
     fun testContextConvertsToObjectMap() {
         val key = "key1"
         val now = Date()
-        val ctx = MutableContext(key)
-        ctx.add("string", Value.String("value"))
-        ctx.add("bool", Value.Boolean(false))
-        ctx.add("integer", Value.Integer(1))
-        ctx.add("double", Value.Double(1.2))
-        ctx.add("date", Value.Date(now))
-        ctx.add("null", Value.Null)
-        ctx.add("list", Value.List(listOf(Value.String("item1"), Value.Boolean(true))))
-        ctx.add(
-            "structure",
-            Value.Structure(
-                mapOf(
-                    "field1" to Value.Integer(3),
-                    "field2" to Value.Double(3.14)
+        val ctx = ImmutableContext(
+            key,
+            mapOf(
+                "string" to Value.String("value"),
+                "bool" to Value.Boolean(false),
+                "integer" to Value.Integer(1),
+                "double" to Value.Double(1.2),
+                "date" to Value.Date(now),
+                "null" to Value.Null,
+                "list" to Value.List(listOf(Value.String("item1"), Value.Boolean(true))),
+                "structure" to Value.Structure(
+                    mapOf(
+                        "field1" to Value.Integer(3),
+                        "field2" to Value.Double(3.14)
+                    )
                 )
             )
         )
@@ -162,8 +160,8 @@ class EvalContextTests {
     fun compareContexts() {
         val map: MutableMap<String, Value> = mutableMapOf("key" to Value.String("test"))
         val map2: MutableMap<String, Value> = mutableMapOf("key" to Value.String("test"))
-        val ctx1 = MutableContext("user1", map)
-        val ctx2 = MutableContext("user1", map2)
+        val ctx1 = ImmutableContext("user1", map)
+        val ctx2 = ImmutableContext("user1", map2)
 
         Assert.assertEquals(ctx1, ctx2)
     }

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/HookSupportTests.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/HookSupportTests.kt
@@ -14,7 +14,7 @@ class HookSupportTests {
             "flagKey",
             FlagValueType.BOOLEAN,
             false,
-            MutableContext(),
+            ImmutableContext(),
             metadata,
             NoOpProvider().metadata
         )

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/ProviderSpecTests.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/ProviderSpecTests.kt
@@ -9,26 +9,26 @@ class ProviderSpecTests {
     fun testFlagValueSet() {
         val provider = NoOpProvider()
 
-        val boolResult = provider.getBooleanEvaluation("key", false, MutableContext())
+        val boolResult = provider.getBooleanEvaluation("key", false, ImmutableContext())
         Assert.assertNotNull(boolResult.value)
 
-        val stringResult = provider.getStringEvaluation("key", "test", MutableContext())
+        val stringResult = provider.getStringEvaluation("key", "test", ImmutableContext())
         Assert.assertNotNull(stringResult.value)
 
-        val intResult = provider.getIntegerEvaluation("key", 4, MutableContext())
+        val intResult = provider.getIntegerEvaluation("key", 4, ImmutableContext())
         Assert.assertNotNull(intResult.value)
 
-        val doubleResult = provider.getDoubleEvaluation("key", 0.4, MutableContext())
+        val doubleResult = provider.getDoubleEvaluation("key", 0.4, ImmutableContext())
         Assert.assertNotNull(doubleResult.value)
 
-        val objectResult = provider.getObjectEvaluation("key", Value.Null, MutableContext())
+        val objectResult = provider.getObjectEvaluation("key", Value.Null, ImmutableContext())
         Assert.assertNotNull(objectResult.value)
     }
 
     @Test
     fun testHasReason() {
         val provider = NoOpProvider()
-        val boolResult = provider.getBooleanEvaluation("key", false, MutableContext())
+        val boolResult = provider.getBooleanEvaluation("key", false, ImmutableContext())
 
         Assert.assertEquals(Reason.DEFAULT.toString(), boolResult.reason)
     }
@@ -36,7 +36,7 @@ class ProviderSpecTests {
     @Test
     fun testNoErrorCodeByDefault() {
         val provider = NoOpProvider()
-        val boolResult = provider.getBooleanEvaluation("key", false, MutableContext())
+        val boolResult = provider.getBooleanEvaluation("key", false, ImmutableContext())
 
         Assert.assertNull(boolResult.errorCode)
     }
@@ -45,19 +45,19 @@ class ProviderSpecTests {
     fun testVariantIsSet() {
         val provider = NoOpProvider()
 
-        val boolResult = provider.getBooleanEvaluation("key", false, MutableContext())
+        val boolResult = provider.getBooleanEvaluation("key", false, ImmutableContext())
         Assert.assertNotNull(boolResult.variant)
 
-        val stringResult = provider.getStringEvaluation("key", "test", MutableContext())
+        val stringResult = provider.getStringEvaluation("key", "test", ImmutableContext())
         Assert.assertNotNull(stringResult.variant)
 
-        val intResult = provider.getIntegerEvaluation("key", 4, MutableContext())
+        val intResult = provider.getIntegerEvaluation("key", 4, ImmutableContext())
         Assert.assertNotNull(intResult.variant)
 
-        val doubleResult = provider.getDoubleEvaluation("key", 0.4, MutableContext())
+        val doubleResult = provider.getDoubleEvaluation("key", 0.4, ImmutableContext())
         Assert.assertNotNull(doubleResult.variant)
 
-        val objectResult = provider.getObjectEvaluation("key", Value.Null, MutableContext())
+        val objectResult = provider.getObjectEvaluation("key", Value.Null, ImmutableContext())
         Assert.assertNotNull(objectResult.variant)
     }
 }

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/StructureTests.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/StructureTests.kt
@@ -8,14 +8,14 @@ class StructureTests {
 
     @Test
     fun testNoArgIsEmpty() {
-        val structure = MutableContext()
+        val structure = ImmutableContext()
         Assert.assertTrue(structure.asMap().keys.isEmpty())
     }
 
     @Test
     fun testArgShouldContainNewMap() {
         val map: MutableMap<String, Value> = mutableMapOf("key" to Value.String("test"))
-        val structure = MutableStructure(map)
+        val structure = ImmutableStructure(map)
 
         Assert.assertEquals("test", structure.getValue("key")?.asString())
         Assert.assertEquals(map, structure.asMap())
@@ -24,14 +24,19 @@ class StructureTests {
     @Test
     fun testAddAndGetReturnValues() {
         val now = Date()
-        val structure = MutableStructure()
-        structure.add("bool", Value.Boolean(true))
-        structure.add("string", Value.String("val"))
-        structure.add("int", Value.Integer(13))
-        structure.add("double", Value.Double(0.5))
-        structure.add("date", Value.Date(now))
-        structure.add("list", Value.List(listOf()))
-        structure.add("structure", Value.Structure(mapOf()))
+        val structure = ImmutableStructure(
+            mapOf(
+                "string" to Value.String("val"),
+                "bool" to Value.Boolean(true),
+                "int" to Value.Integer(13),
+                "double" to Value.Double(0.5),
+                "date" to Value.Date(now),
+                "list" to Value.List(listOf()),
+                "structure" to Value.Structure(
+                    mapOf()
+                )
+            )
+        )
 
         Assert.assertEquals(true, structure.getValue("bool")?.asBoolean())
         Assert.assertEquals("val", structure.getValue("string")?.asString())
@@ -46,8 +51,8 @@ class StructureTests {
     fun testCompareStructure() {
         val map: MutableMap<String, Value> = mutableMapOf("key" to Value.String("test"))
         val map2: MutableMap<String, Value> = mutableMapOf("key" to Value.String("test"))
-        val structure1 = MutableStructure(map)
-        val structure2 = MutableStructure(map2)
+        val structure1 = ImmutableStructure(map)
+        val structure2 = ImmutableStructure(map2)
 
         Assert.assertEquals(structure1, structure2)
     }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ dependencies {
 import dev.openfeature.sdk.*
 
 // Change NoOpProvider with your actual provider
-OpenFeatureAPI.setProvider(NoOpProvider(), MutableContext())
+OpenFeatureAPI.setProvider(NoOpProvider(), ImmutableContext())
 val flagValue = OpenFeatureAPI.getClient().getBooleanValue("boolFlag", false)
 ```
 Setting a new provider or setting a new evaluation context are asynchronous operations. The provider might execute I/O operations as part of these method calls (e.g. fetching flag evaluations from the backend and store them in a local cache). It's advised to not interact with the OpenFeature client until the `setProvider()` or `setEvaluationContext()` functions have returned successfully.


### PR DESCRIPTION
Immutable data structures are safer in multi-threaded environments