### PR TITLE
Different Metadata interfaces client/provider

### DIFF
--- a/OpenFeature/src/main/java/dev/openfeature/sdk/Client.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/Client.kt
@@ -1,7 +1,7 @@
 package dev.openfeature.sdk
 
 interface Client : Features {
-    val metadata: Metadata
+    val metadata: ClientMetadata
     val hooks: List<Hook<*>>
 
     fun addHooks(hooks: List<Hook<*>>)

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/ClientMetadata.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/ClientMetadata.kt
@@ -1,0 +1,5 @@
+package dev.openfeature.sdk
+
+interface ClientMetadata {
+    val name: String?
+}

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/FeatureProvider.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/FeatureProvider.kt
@@ -2,7 +2,7 @@ package dev.openfeature.sdk
 
 interface FeatureProvider {
     val hooks: List<Hook<*>>
-    val metadata: Metadata
+    val metadata: ProviderMetadata
 
     // Called by OpenFeatureAPI whenever the new Provider is registered
     suspend fun initialize(initialContext: EvaluationContext?)

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/HookContext.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/HookContext.kt
@@ -5,6 +5,6 @@ data class HookContext<T>(
     val type: FlagValueType,
     var defaultValue: T,
     var ctx: EvaluationContext?,
-    var clientMetadata: Metadata?,
-    var providerMetadata: Metadata
+    var clientMetadata: ClientMetadata?,
+    var providerMetadata: ProviderMetadata
 )

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/NoOpProvider.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/NoOpProvider.kt
@@ -1,7 +1,7 @@
 package dev.openfeature.sdk
 
 class NoOpProvider : FeatureProvider {
-    override var metadata: Metadata = NoOpMetadata("No-op provider")
+    override var metadata: ProviderMetadata = NoOpProviderMetadata("No-op provider")
     override suspend fun initialize(initialContext: EvaluationContext?) {
         // no-op
     }
@@ -54,5 +54,5 @@ class NoOpProvider : FeatureProvider {
         return ProviderEvaluation(defaultValue, "Passed in default", Reason.DEFAULT.toString())
     }
 
-    data class NoOpMetadata(override var name: String?) : Metadata
+    data class NoOpProviderMetadata(override var name: String?) : ProviderMetadata
 }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.kt
@@ -35,7 +35,7 @@ object OpenFeatureAPI {
         return context
     }
 
-    fun getProviderMetadata(): Metadata? {
+    fun getProviderMetadata(): ProviderMetadata? {
         return provider?.metadata
     }
 

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/OpenFeatureClient.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/OpenFeatureClient.kt
@@ -17,7 +17,7 @@ class OpenFeatureClient(
     version: String? = null,
     override val hooks: MutableList<Hook<*>> = mutableListOf()
 ) : Client {
-    override val metadata: Metadata = ClientMetadata(name)
+    override val metadata: ClientMetadata = Metadata(name)
     private var hookSupport = HookSupport()
     override fun addHooks(hooks: List<Hook<*>>) {
         this.hooks += hooks
@@ -242,5 +242,5 @@ class OpenFeatureClient(
         }
     }
 
-    data class ClientMetadata(override var name: String?) : Metadata
+    data class Metadata(override var name: String?) : ClientMetadata
 }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/ProviderMetadata.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/ProviderMetadata.kt
@@ -1,5 +1,5 @@
 package dev.openfeature.sdk
 
-interface Metadata {
+interface ProviderMetadata {
     val name: String?
 }

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/AlwaysBrokenProvider.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/AlwaysBrokenProvider.kt
@@ -3,12 +3,12 @@ package dev.openfeature.sdk.helpers
 import dev.openfeature.sdk.EvaluationContext
 import dev.openfeature.sdk.FeatureProvider
 import dev.openfeature.sdk.Hook
-import dev.openfeature.sdk.Metadata
 import dev.openfeature.sdk.ProviderEvaluation
+import dev.openfeature.sdk.ProviderMetadata
 import dev.openfeature.sdk.Value
 import dev.openfeature.sdk.exceptions.OpenFeatureError.FlagNotFoundError
 
-class AlwaysBrokenProvider(override var hooks: List<Hook<*>> = listOf(), override var metadata: Metadata = AlwaysBrokenMetadata()) :
+class AlwaysBrokenProvider(override var hooks: List<Hook<*>> = listOf(), override var metadata: ProviderMetadata = AlwaysBrokenProviderMetadata()) :
     FeatureProvider {
     override suspend fun initialize(initialContext: EvaluationContext?) {
         // no-op
@@ -61,5 +61,5 @@ class AlwaysBrokenProvider(override var hooks: List<Hook<*>> = listOf(), overrid
         throw FlagNotFoundError(key)
     }
 
-    class AlwaysBrokenMetadata(override var name: String? = "test") : Metadata
+    class AlwaysBrokenProviderMetadata(override var name: String? = "test") : ProviderMetadata
 }

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/DoSomethingProvider.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/DoSomethingProvider.kt
@@ -3,11 +3,11 @@ package dev.openfeature.sdk.helpers
 import dev.openfeature.sdk.EvaluationContext
 import dev.openfeature.sdk.FeatureProvider
 import dev.openfeature.sdk.Hook
-import dev.openfeature.sdk.Metadata
 import dev.openfeature.sdk.ProviderEvaluation
+import dev.openfeature.sdk.ProviderMetadata
 import dev.openfeature.sdk.Value
 
-class DoSomethingProvider(override val hooks: List<Hook<*>> = listOf(), override val metadata: Metadata = DoSomethingMetadata()) : FeatureProvider {
+class DoSomethingProvider(override val hooks: List<Hook<*>> = listOf(), override val metadata: ProviderMetadata = DoSomethingProviderMetadata()) : FeatureProvider {
     override suspend fun initialize(initialContext: EvaluationContext?) {
         // no-op
     }
@@ -58,5 +58,5 @@ class DoSomethingProvider(override val hooks: List<Hook<*>> = listOf(), override
     ): ProviderEvaluation<Value> {
         return ProviderEvaluation(Value.Null)
     }
-    class DoSomethingMetadata(override var name: String? = "something") : Metadata
+    class DoSomethingProviderMetadata(override var name: String? = "something") : ProviderMetadata
 }


### PR DESCRIPTION
The different Metadata models can evolve independently.
The more specific naming also helps clarifying which objects each metadata interface is associated with, which will be even more useful when new metadata will be introduced in other objects types.  