### PR TITLE
Restructure setters in OpenFeatureAPI

### DIFF
--- a/OpenFeature/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.kt
@@ -9,9 +9,9 @@ object OpenFeatureAPI {
         private set
 
     suspend fun setProvider(provider: FeatureProvider, initialContext: EvaluationContext? = null) = coroutineScope {
-        provider.initialize(initialContext ?: context)
         this@OpenFeatureAPI.provider = provider
         if (initialContext != null) context = initialContext
+        provider.initialize(context)
     }
 
     fun getProvider(): FeatureProvider? {
@@ -23,12 +23,8 @@ object OpenFeatureAPI {
     }
 
     suspend fun setEvaluationContext(evaluationContext: EvaluationContext) {
-        getProvider()?.onContextSet(context, evaluationContext)
-        // A provider evaluation reading the global ctx at this point would fail due to stale cache.
-        // To prevent this, the provider should internally manage the ctx to use on each evaluation, and
-        // make sure it's aligned with the values in the cache at all times. If no guarantees are offered by
-        // the provider, the application can expect STALE resolves while setting a new global ctx
         context = evaluationContext
+        getProvider()?.onContextSet(context, evaluationContext)
     }
 
     fun getEvaluationContext(): EvaluationContext? {


### PR DESCRIPTION
The idea is to set the global parameters _before_ applying any side effect within the underlying Provider.
For example, while the Provider is processing a new context (i.e. `onContextSet()` is running), that new context is already set in the global API and it is the context used for future evaluation reads: this makes it less likely for the Providers to return data associated to an older evaluation context _after_ the application has already called `setEvaluationContext()` 

### Step by step scenario
- "contextA" and flag cache for "contextA" are used during a certain app's session
- The application calls "setEvaluationContext(contextB)"
- While the provider is fetching the flags data for contextB, the application calls the provider's evaluation APIs (already expecting data for "contextB")
  - Before this PR, it's possible that the global context is still "contextA" and that the underlying Provide hasn't yet updated the cache with contextB data, resulting in contextA data being returned (while the app expects contextB data)

Same change on the Swift SDK: https://github.com/spotify/openfeature-swift-sdk/pull/19