### PR TITLE
Add Events and async client

### DIFF
--- a/OpenFeature/build.gradle.kts
+++ b/OpenFeature/build.gradle.kts
@@ -37,10 +37,11 @@ android {
 }
 
 dependencies {
-    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.1")
-    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.4.1")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-core:1.7.2")
+    implementation("org.jetbrains.kotlinx:kotlinx-serialization-json:1.5.1")
     testImplementation("junit:junit:4.13.2")
-    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.1")
+    testImplementation("org.mockito.kotlin:mockito-kotlin:5.0.0")
+    testImplementation("org.jetbrains.kotlinx:kotlinx-coroutines-test:1.7.2")
 }
 
 afterEvaluate {

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/FeatureProvider.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/FeatureProvider.kt
@@ -5,10 +5,14 @@ interface FeatureProvider {
     val metadata: ProviderMetadata
 
     // Called by OpenFeatureAPI whenever the new Provider is registered
-    suspend fun initialize(initialContext: EvaluationContext?)
+    fun initialize(initialContext: EvaluationContext?)
+
+    // called when the lifecycle of the OpenFeatureClient is over
+    // to release resources/threads.
+    fun shutdown()
 
     // Called by OpenFeatureAPI whenever a new EvaluationContext is set by the application
-    suspend fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext)
+    fun onContextSet(oldContext: EvaluationContext?, newContext: EvaluationContext)
     fun getBooleanEvaluation(
         key: String,
         defaultValue: Boolean,

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/NoOpProvider.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/NoOpProvider.kt
@@ -2,11 +2,15 @@ package dev.openfeature.sdk
 
 class NoOpProvider : FeatureProvider {
     override var metadata: ProviderMetadata = NoOpProviderMetadata("No-op provider")
-    override suspend fun initialize(initialContext: EvaluationContext?) {
+    override fun initialize(initialContext: EvaluationContext?) {
         // no-op
     }
 
-    override suspend fun onContextSet(
+    override fun shutdown() {
+        // no-op
+    }
+
+    override fun onContextSet(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext
     ) {

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.kt
@@ -1,14 +1,12 @@
 package dev.openfeature.sdk
 
-import kotlinx.coroutines.coroutineScope
-
 object OpenFeatureAPI {
     private var provider: FeatureProvider? = null
     private var context: EvaluationContext? = null
     var hooks: List<Hook<*>> = listOf()
         private set
 
-    suspend fun setProvider(provider: FeatureProvider, initialContext: EvaluationContext? = null) = coroutineScope {
+    fun setProvider(provider: FeatureProvider, initialContext: EvaluationContext? = null) {
         this@OpenFeatureAPI.provider = provider
         if (initialContext != null) context = initialContext
         provider.initialize(context)
@@ -22,7 +20,7 @@ object OpenFeatureAPI {
         provider = null
     }
 
-    suspend fun setEvaluationContext(evaluationContext: EvaluationContext) {
+    fun setEvaluationContext(evaluationContext: EvaluationContext) {
         context = evaluationContext
         getProvider()?.onContextSet(context, evaluationContext)
     }
@@ -45,5 +43,9 @@ object OpenFeatureAPI {
 
     fun clearHooks() {
         this.hooks = listOf()
+    }
+
+    fun shutdown() {
+        provider?.shutdown()
     }
 }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/async/AsyncClient.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/async/AsyncClient.kt
@@ -1,0 +1,45 @@
+package dev.openfeature.sdk.async
+
+import dev.openfeature.sdk.OpenFeatureClient
+import dev.openfeature.sdk.events.EventObserver
+import dev.openfeature.sdk.events.OpenFeatureEvents
+import dev.openfeature.sdk.events.ProviderStatus
+import dev.openfeature.sdk.events.observe
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.onStart
+
+interface AsyncClient {
+    fun observeBooleanValue(key: String, default: Boolean): Flow<Boolean>
+    fun observeIntValue(key: String, default: Int): Flow<Int>
+    fun observeStringValue(key: String, default: String): Flow<String>
+}
+
+internal class AsyncClientImpl(
+    private val client: OpenFeatureClient,
+    private val eventsObserver: EventObserver,
+    private val providerStatus: ProviderStatus
+) : AsyncClient {
+    private fun <T> observeEvents(callback: () -> T) = eventsObserver
+        .observe<OpenFeatureEvents.ProviderReady>()
+        .onStart {
+            if (providerStatus.isProviderReady()) {
+                this.emit(OpenFeatureEvents.ProviderReady)
+            }
+        }
+        .map { callback() }
+        .distinctUntilChanged()
+
+    override fun observeBooleanValue(key: String, default: Boolean) = observeEvents {
+        client.getBooleanValue(key, default)
+    }
+
+    override fun observeIntValue(key: String, default: Int) = observeEvents {
+        client.getIntegerValue(key, default)
+    }
+
+    override fun observeStringValue(key: String, default: String) = observeEvents {
+        client.getStringValue(key, default)
+    }
+}

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/async/AsyncClient.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/async/AsyncClient.kt
@@ -1,6 +1,7 @@
 package dev.openfeature.sdk.async
 
 import dev.openfeature.sdk.OpenFeatureClient
+import dev.openfeature.sdk.Value
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.map
@@ -9,6 +10,8 @@ interface AsyncClient {
     fun observeBooleanValue(key: String, default: Boolean): Flow<Boolean>
     fun observeIntValue(key: String, default: Int): Flow<Int>
     fun observeStringValue(key: String, default: String): Flow<String>
+    fun observeDoubleValue(key: String, default: Double): Flow<Double>
+    fun observeValue(key: String, default: Value): Flow<Value>
 }
 
 internal class AsyncClientImpl(
@@ -28,5 +31,13 @@ internal class AsyncClientImpl(
 
     override fun observeStringValue(key: String, default: String) = observeEvents {
         client.getStringValue(key, default)
+    }
+
+    override fun observeDoubleValue(key: String, default: Double): Flow<Double> = observeEvents {
+        client.getDoubleValue(key, default)
+    }
+
+    override fun observeValue(key: String, default: Value): Flow<Value> = observeEvents {
+        client.getObjectValue(key, default)
     }
 }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/async/Extensions.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/async/Extensions.kt
@@ -10,12 +10,10 @@ fun OpenFeatureClient.toAsync(): AsyncClient {
     return AsyncClientImpl(this)
 }
 
-fun observeProviderReady() = observeProviderEvents()
+fun observeProviderReady() = EventHandler.eventsObserver()
     .observe<OpenFeatureEvents.ProviderReady>()
     .onStart {
         if (EventHandler.providerStatus().isProviderReady()) {
             this.emit(OpenFeatureEvents.ProviderReady)
         }
     }
-
-fun observeProviderEvents() = EventHandler.eventsObserver()

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/async/Extensions.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/async/Extensions.kt
@@ -1,0 +1,30 @@
+package dev.openfeature.sdk.async
+
+import dev.openfeature.sdk.OpenFeatureClient
+import dev.openfeature.sdk.events.EventHandler
+import dev.openfeature.sdk.events.EventObserver
+import dev.openfeature.sdk.events.OpenFeatureEvents
+import dev.openfeature.sdk.events.ProviderStatus
+import dev.openfeature.sdk.events.observe
+import kotlinx.coroutines.flow.onStart
+
+fun OpenFeatureClient.toAsync(): AsyncClient {
+    val eventsObserver: EventObserver = EventHandler.eventsObserver()
+    val providerStatus: ProviderStatus = EventHandler.providerStatus()
+
+    return AsyncClientImpl(
+        this,
+        eventsObserver,
+        providerStatus
+    )
+}
+
+fun observeProviderStatus() = observeProviderEvents()
+    .observe<OpenFeatureEvents.ProviderReady>()
+    .onStart {
+        if (EventHandler.providerStatus().isProviderReady()) {
+            this.emit(OpenFeatureEvents.ProviderReady)
+        }
+    }
+
+fun observeProviderEvents() = EventHandler.eventsObserver()

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/async/Extensions.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/async/Extensions.kt
@@ -4,16 +4,46 @@ import dev.openfeature.sdk.OpenFeatureClient
 import dev.openfeature.sdk.events.EventHandler
 import dev.openfeature.sdk.events.OpenFeatureEvents
 import dev.openfeature.sdk.events.observe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
 import kotlinx.coroutines.flow.onStart
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.suspendCancellableCoroutine
 
 fun OpenFeatureClient.toAsync(): AsyncClient {
     return AsyncClientImpl(this)
 }
 
-fun observeProviderReady() = EventHandler.eventsObserver()
+internal fun observeProviderReady() = EventHandler.eventsObserver()
     .observe<OpenFeatureEvents.ProviderReady>()
     .onStart {
         if (EventHandler.providerStatus().isProviderReady()) {
             this.emit(OpenFeatureEvents.ProviderReady)
         }
     }
+
+suspend fun awaitProviderReady() = suspendCancellableCoroutine { continuation ->
+    val coroutineScope = CoroutineScope(Dispatchers.IO)
+    coroutineScope.launch {
+        observeProviderReady()
+            .take(1)
+            .collect {
+                continuation.resumeWith(Result.success(Unit))
+            }
+    }
+
+    coroutineScope.launch {
+        EventHandler.eventsObserver()
+            .observe<OpenFeatureEvents.ProviderError>()
+            .take(1)
+            .collect {
+                continuation.resumeWith(Result.failure(it.error))
+            }
+    }
+
+    continuation.invokeOnCancellation {
+        coroutineScope.cancel()
+    }
+}

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/events/EventPublisher.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/events/EventPublisher.kt
@@ -1,0 +1,77 @@
+package dev.openfeature.sdk.events
+
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.cancel
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableSharedFlow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.filterIsInstance
+import kotlinx.coroutines.launch
+import kotlin.reflect.KClass
+
+interface ProviderStatus {
+    fun isProviderReady(): Boolean
+}
+
+interface EventObserver {
+    fun <T : OpenFeatureEvents> observe(kClass: KClass<T>): Flow<T>
+}
+
+interface EventsPublisher {
+    fun publish(event: OpenFeatureEvents)
+}
+
+inline fun <reified T : OpenFeatureEvents> EventObserver.observe() = observe(T::class)
+
+class EventHandler : EventObserver, EventsPublisher, ProviderStatus {
+    private val sharedFlow: MutableSharedFlow<OpenFeatureEvents> = MutableSharedFlow()
+    private val isProviderReady = MutableStateFlow(false)
+    private val coroutineScope = CoroutineScope(Dispatchers.IO)
+
+    init {
+        coroutineScope.launch {
+            sharedFlow.collect {
+                when (it) {
+                    is OpenFeatureEvents.ProviderReady -> isProviderReady.value = true
+                    is OpenFeatureEvents.ProviderShutDown -> {
+                        isProviderReady.value = false
+                        coroutineScope.cancel()
+                    }
+                    else -> {
+                        // do nothing
+                    }
+                }
+            }
+        }
+    }
+
+    override fun publish(event: OpenFeatureEvents) {
+        coroutineScope.launch {
+            sharedFlow.emit(event)
+        }
+    }
+
+    override fun isProviderReady(): Boolean {
+        return isProviderReady.value
+    }
+
+    override fun <T : OpenFeatureEvents> observe(kClass: KClass<T>): Flow<T> = sharedFlow
+        .filterIsInstance(kClass)
+
+    companion object {
+        @Volatile
+        private var instance: EventHandler? = null
+
+        private fun getInstance() =
+            instance ?: synchronized(this) {
+                instance ?: create().also { instance = it }
+            }
+
+        fun eventsObserver(): EventObserver = getInstance()
+        fun providerStatus(): ProviderStatus = getInstance()
+        fun eventsPublisher(): EventsPublisher = getInstance()
+
+        private fun create() = EventHandler()
+    }
+}

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/events/OpenFeatureEvents.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/events/OpenFeatureEvents.kt
@@ -3,7 +3,7 @@ package dev.openfeature.sdk.events
 sealed class OpenFeatureEvents {
     object ProviderReady : OpenFeatureEvents()
     object ProviderConfigurationChanged : OpenFeatureEvents()
-    object ProviderError : OpenFeatureEvents()
+    data class ProviderError(val error: Throwable) : OpenFeatureEvents()
     object ProviderStale : OpenFeatureEvents()
     object ProviderShutDown : OpenFeatureEvents()
 }

--- a/OpenFeature/src/main/java/dev/openfeature/sdk/events/OpenFeatureEvents.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/events/OpenFeatureEvents.kt
@@ -1,0 +1,9 @@
+package dev.openfeature.sdk.events
+
+sealed class OpenFeatureEvents {
+    object ProviderReady : OpenFeatureEvents()
+    object ProviderConfigurationChanged : OpenFeatureEvents()
+    object ProviderError : OpenFeatureEvents()
+    object ProviderStale : OpenFeatureEvents()
+    object ProviderShutDown : OpenFeatureEvents()
+}

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/EventsHandlerTest.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/EventsHandlerTest.kt
@@ -101,7 +101,8 @@ class EventsHandlerTest {
 
         // observing the provider status after the provider ready event is published
         val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            observeProviderReady()
+            EventHandler.eventsObserver()
+                .observe<OpenFeatureEvents.ProviderReady>()
                 .take(1)
                 .collect {
                     isProviderReady = true
@@ -119,7 +120,8 @@ class EventsHandlerTest {
 
         // observing the provider status after the provider ready event is published
         val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
-            observeProviderReady()
+            EventHandler.eventsObserver()
+                .observe<OpenFeatureEvents.ProviderReady>()
                 .timeout(10L.milliseconds)
                 .collect {
                     isProviderReady = true

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/EventsHandlerTest.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/EventsHandlerTest.kt
@@ -1,0 +1,209 @@
+package dev.openfeature.sdk
+
+import dev.openfeature.sdk.async.observeProviderReady
+import dev.openfeature.sdk.async.toAsync
+import dev.openfeature.sdk.events.EventHandler
+import dev.openfeature.sdk.events.OpenFeatureEvents
+import dev.openfeature.sdk.events.observe
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
+import kotlinx.coroutines.flow.take
+import kotlinx.coroutines.flow.timeout
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.UnconfinedTestDispatcher
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mockito.`when`
+import org.mockito.kotlin.doReturn
+import org.mockito.kotlin.mock
+import kotlin.time.Duration.Companion.milliseconds
+
+@OptIn(ExperimentalCoroutinesApi::class)
+class EventsHandlerTest {
+
+    @Test
+    fun observing_event_observer_works() = runTest {
+        val eventObserver = EventHandler.eventsObserver()
+        val eventPublisher = EventHandler.eventsPublisher()
+        var emitted = false
+
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            eventObserver.observe<OpenFeatureEvents.ProviderReady>()
+                .take(1)
+                .collect {
+                    emitted = true
+                }
+        }
+
+        eventPublisher.publish(OpenFeatureEvents.ProviderReady)
+        job.join()
+        Assert.assertTrue(emitted)
+    }
+
+    @Test
+    fun multiple_subscribers_works() = runTest {
+        val eventObserver = EventHandler.eventsObserver()
+        val eventPublisher = EventHandler.eventsPublisher()
+        val numberOfSubscribers = 10
+        val parentJob = Job()
+        var emitted = 0
+
+        repeat(numberOfSubscribers) {
+            CoroutineScope(parentJob).launch(UnconfinedTestDispatcher(testScheduler)) {
+                eventObserver.observe<OpenFeatureEvents.ProviderReady>()
+                    .take(1)
+                    .collect {
+                        emitted += 1
+                    }
+            }
+        }
+
+        eventPublisher.publish(OpenFeatureEvents.ProviderReady)
+        parentJob.children.forEach { it.join() }
+        Assert.assertTrue(emitted == 10)
+    }
+
+    @Test
+    fun canceling_one_subscriber_does_not_cancel_others() = runTest {
+        val eventObserver = EventHandler.eventsObserver()
+        val eventPublisher = EventHandler.eventsPublisher()
+        val numberOfSubscribers = 10
+        val parentJob = Job()
+        var emitted = 0
+
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            eventObserver.observe<OpenFeatureEvents.ProviderReady>()
+                .take(1)
+                .collect {}
+        }
+
+        repeat(numberOfSubscribers) {
+            CoroutineScope(parentJob).launch(UnconfinedTestDispatcher(testScheduler)) {
+                eventObserver.observe<OpenFeatureEvents.ProviderReady>()
+                    .take(1)
+                    .collect {
+                        emitted += 1
+                    }
+            }
+        }
+        job.cancel()
+        eventPublisher.publish(OpenFeatureEvents.ProviderReady)
+        parentJob.children.forEach { it.join() }
+        Assert.assertTrue(emitted == 10)
+    }
+
+    @Test
+    fun the_provider_status_stream_works() = runTest {
+        val eventPublisher = EventHandler.eventsPublisher()
+        var isProviderReady = false
+
+        // observing the provider status after the provider ready event is published
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            observeProviderReady()
+                .take(1)
+                .collect {
+                    isProviderReady = true
+                }
+        }
+
+        eventPublisher.publish(OpenFeatureEvents.ProviderReady)
+        job.join()
+        Assert.assertTrue(isProviderReady)
+    }
+
+    @Test
+    fun the_provider_status_stream_not_emitting_without_event_published() = runTest {
+        var isProviderReady = false
+
+        // observing the provider status after the provider ready event is published
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            observeProviderReady()
+                .timeout(10L.milliseconds)
+                .collect {
+                    isProviderReady = true
+                }
+        }
+
+        job.join()
+        Assert.assertTrue(!isProviderReady)
+    }
+
+    @Test
+    fun the_provider_status_stream_is_replays_current_status() = runTest {
+        val eventPublisher = EventHandler.eventsPublisher()
+        eventPublisher.publish(OpenFeatureEvents.ProviderReady)
+        var isProviderReady = false
+
+        // observing the provider status after the provider ready event is published
+        val job = backgroundScope.launch(UnconfinedTestDispatcher(testScheduler)) {
+            observeProviderReady()
+                .take(1)
+                .collect {
+                    isProviderReady = true
+                }
+        }
+
+        job.join()
+        Assert.assertTrue(isProviderReady)
+    }
+
+    @Test
+    fun observe_string_value_from_client_works() = runTest {
+        val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val eventPublisher = EventHandler.eventsPublisher(testDispatcher)
+        eventPublisher.publish(OpenFeatureEvents.ProviderReady)
+        val key = "mykey"
+        val default = "default"
+        val resultTexts = mutableListOf<String>()
+
+        val mockOpenFeatureClient = mock<OpenFeatureClient> {
+            on { getStringValue(key, default) } doReturn "text1"
+        }
+
+        // observing the provider status after the provider ready event is published
+        val job = backgroundScope.launch(testDispatcher) {
+            mockOpenFeatureClient.toAsync()
+                .observeStringValue(key, default)
+                .take(2)
+                .collect {
+                    resultTexts.add(it)
+                }
+        }
+
+        `when`(mockOpenFeatureClient.getStringValue(key, default))
+            .thenReturn("text2")
+
+        eventPublisher.publish(OpenFeatureEvents.ProviderReady)
+        job.join()
+        Assert.assertEquals(listOf("text1", "text2"), resultTexts)
+    }
+
+    @Test
+    fun observe_string_value_from_client_waits_until_provider_ready() = runTest {
+        val testDispatcher = UnconfinedTestDispatcher(testScheduler)
+        val eventPublisher = EventHandler.eventsPublisher(testDispatcher)
+        val key = "mykey"
+        val default = "default"
+        val resultTexts = mutableListOf<String>()
+
+        val mockOpenFeatureClient = mock<OpenFeatureClient> {
+            on { getStringValue(key, default) } doReturn "text1"
+        }
+
+        // observing the provider status after the provider ready event is published
+        val job = backgroundScope.launch(testDispatcher) {
+            mockOpenFeatureClient.toAsync()
+                .observeStringValue(key, default)
+                .take(1)
+                .collect {
+                    resultTexts.add(it)
+                }
+        }
+
+        eventPublisher.publish(OpenFeatureEvents.ProviderReady)
+        job.join()
+        Assert.assertEquals(listOf("text1"), resultTexts)
+    }
+}

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/AlwaysBrokenProvider.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/AlwaysBrokenProvider.kt
@@ -10,11 +10,15 @@ import dev.openfeature.sdk.exceptions.OpenFeatureError.FlagNotFoundError
 
 class AlwaysBrokenProvider(override var hooks: List<Hook<*>> = listOf(), override var metadata: ProviderMetadata = AlwaysBrokenProviderMetadata()) :
     FeatureProvider {
-    override suspend fun initialize(initialContext: EvaluationContext?) {
+    override fun initialize(initialContext: EvaluationContext?) {
         // no-op
     }
 
-    override suspend fun onContextSet(
+    override fun shutdown() {
+        // no-op
+    }
+
+    override fun onContextSet(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext
     ) {

--- a/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/DoSomethingProvider.kt
+++ b/OpenFeature/src/test/java/dev/openfeature/sdk/helpers/DoSomethingProvider.kt
@@ -8,11 +8,15 @@ import dev.openfeature.sdk.ProviderMetadata
 import dev.openfeature.sdk.Value
 
 class DoSomethingProvider(override val hooks: List<Hook<*>> = listOf(), override val metadata: ProviderMetadata = DoSomethingProviderMetadata()) : FeatureProvider {
-    override suspend fun initialize(initialContext: EvaluationContext?) {
+    override fun initialize(initialContext: EvaluationContext?) {
         // no-op
     }
 
-    override suspend fun onContextSet(
+    override fun shutdown() {
+        // no-op
+    }
+
+    override fun onContextSet(
         oldContext: EvaluationContext?,
         newContext: EvaluationContext
     ) {


### PR DESCRIPTION
* Add basics for adding the events
* Add extension to convert the client to the async client.

To do some actions after provider is ready:

```
CoroutineScope(Dispatchers.IO).launch {
        awaitProviderReady()
        // now provider is ready, read the properties
    }
```

The usage will be something like:

```
openFeatureClient
.toAsync()
.observeStringValue(key, default)
.collect { 
// do something with boolean
}
```

in the compose world will be:
```
val myStringProperty = openFeatureClient
.toAsync()
.observeStringValue(key, default)
.collectAsState()
```

we can update the implementation to limit the value emissions only for when the provider is initialised and ready to not emit the default value if the provider is not ready.