### PR TITLE
Bug fix in setEvaluationContext

### DIFF
--- a/OpenFeature/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.kt
+++ b/OpenFeature/src/main/java/dev/openfeature/sdk/OpenFeatureAPI.kt
@@ -32,8 +32,9 @@ object OpenFeatureAPI {
     }
 
     fun setEvaluationContext(evaluationContext: EvaluationContext) {
+        val oldContext = context
         context = evaluationContext
-        getProvider()?.onContextSet(context, evaluationContext)
+        getProvider()?.onContextSet(oldContext, evaluationContext)
     }
 
     fun getEvaluationContext(): EvaluationContext? {


### PR DESCRIPTION
Introduced [here](https://github.com/spotify/openfeature-kotlin-sdk/pull/30), the code was passing the new context as old context to the Provider. This PR fixes that behaviour, while still ensuring the global ctx is set before the Provider's `onContextSet` is called  